### PR TITLE
feat: persist AICAData via localStorage

### DIFF
--- a/common.js
+++ b/common.js
@@ -33,12 +33,6 @@ function encodeFileName(str) {
 }
 
 //#region 全体的なデータの準備
-// 画面遷移時にデータを取得
-window.electronAPI.onPageData((data) => {
-    console.log('Received data:', data);
-    window.AICAData = data;
-});
-
 // XMLデータをロード
 function loadXMLData(callback = () => { }) {
     window.electronAPI.loadXML()
@@ -125,6 +119,17 @@ function deserializeAICAData(data) {
 
     return data;
 }
+
+// localStorageからデータを復元
+const storedAICAData = localStorage.getItem('AICAData');
+if (storedAICAData) {
+    try {
+        window.AICAData = deserializeAICAData(JSON.parse(storedAICAData));
+    } catch (e) {
+        console.error('Failed to parse AICAData from localStorage:', e);
+    }
+}
+
 //#endregion 全体的なデータの準備
 
 //#region ユーザー（コーチ）のデータ

--- a/finish.html
+++ b/finish.html
@@ -87,30 +87,25 @@ $password = $_POST['password'] ?? '';
     <script src="common.js"></script>
 
     <script>
-        window.electronAPI.onPageData((data) => {
-            // デシリアライズ関数を使用
-            window.AICAData = deserializeAICAData(data);
+        window.AICAData = deserializeAICAData(JSON.parse(localStorage.getItem('AICAData') || '{}'));
 
-            // データの確認
-            if (window.AICAData.xmlData) {
-                // xmlData を使用した処理
-            } else {
-                console.warn('xmlData is null');
-            }
+        // データの確認
+        if (window.AICAData.xmlData) {
+            // xmlData を使用した処理
+        } else {
+            console.warn('xmlData is null');
+        }
 
-            if (window.AICAData.sessionDataXML) {
-                // sessionXML を使用した処理
-            } else {
-                console.warn('sessionDataXML is null');
-            }
+        if (window.AICAData.sessionDataXML) {
+            // sessionXML を使用した処理
+        } else {
+            console.warn('sessionDataXML is null');
+        }
 
-            // その他の処理を続行
-            // クライアント情報をロード
-            findLatestSessionClientData(afterFindLastSession);
+        // その他の処理を続行
+        // クライアント情報をロード
+        findLatestSessionClientData(afterFindLastSession);
 
-        });
-        // 準備完了を通知
-        //window.electronAPI.rendererReady();
         window.currentHtml = "finish";
         window.isRunning = false;
         function afterFindLastSession() {
@@ -165,7 +160,8 @@ $password = $_POST['password'] ?? '';
         // メイン画面に戻るボタンの処理
 
         document.getElementById('back-btn').addEventListener('click', () => {
-            window.electronAPI.switchHtmlWithData('ui-smpl.html', serializeAICAData(window.AICAData));
+            localStorage.setItem('AICAData', JSON.stringify(serializeAICAData(window.AICAData)));
+            window.electronAPI.switchHtml('ui-smpl.html');
         });
 
     </script>

--- a/main.js
+++ b/main.js
@@ -304,16 +304,6 @@ ipcMain.on('switch-html', (event, page) => {
     }
 });
 
-ipcMain.on('switch-html-with-data', (event, page, data) => {
-    const window = BrowserWindow.getFocusedWindow();
-    if (window) {
-        window.loadFile(page).then(() => {
-            // ページがロードされた後にデータを送信
-            window.webContents.send('page-data', data);
-        });
-    }
-});
-
 ////////////////////////////
 //#region ↓↓↓↓　PDF操作　↓↓↓↓　
 ipcMain.handle('create-and-send-pdf', async (event, pdfContent, date, password, recipientEmail, senderName, recipientName) => {

--- a/preload.js
+++ b/preload.js
@@ -9,8 +9,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // createPDF: (data) => ipcRenderer.send('create-pdf', data),
     // onPdfCreated: (callback) => ipcRenderer.on('pdf-created', callback),
     switchHtml: (page) => ipcRenderer.send('switch-html', page),
-    switchHtmlWithData: (page, data) => ipcRenderer.send('switch-html-with-data', page, data),
-    onPageData: (callback) => ipcRenderer.once('page-data', (event, data) => callback(data)),
     saveXML: (xmlString) => ipcRenderer.invoke('save-xml', xmlString),
     loadXML: () => ipcRenderer.invoke('load-xml'),
     saveSession: (sessionFilePath, sessionXMLString) => ipcRenderer.invoke('save-session', sessionFilePath, sessionXMLString),

--- a/renew_clientdata.html
+++ b/renew_clientdata.html
@@ -216,10 +216,7 @@
     <button id="back-btn">メイン画面に戻る</button></div>
     <script src="common.js"></script>
     <script>
-        window.electronAPI.onPageData((data) => {
-            window.AICAData = deserializeAICAData(data);
-            // データを使用する処理
-        });
+        window.AICAData = deserializeAICAData(JSON.parse(localStorage.getItem('AICAData') || '{}'));
         // 準備完了を通知
         //window.electronAPI.rendererReady();
 
@@ -257,7 +254,8 @@
         }
         // 画面切り替え
         document.getElementById('back-btn').addEventListener('click', () => {
-            window.electronAPI.switchHtmlWithData('ui-smpl.html', serializeAICAData(window.AICAData));
+            localStorage.setItem('AICAData', JSON.stringify(serializeAICAData(window.AICAData)));
+            window.electronAPI.switchHtml('ui-smpl.html');
         });
     </script>
 

--- a/renew_userdata.html
+++ b/renew_userdata.html
@@ -112,10 +112,7 @@ renew_clientdata.htmlでのユーザーデータのアップデートとやり�
 
         // 準備完了を通知
         // window.electronAPI.rendererReady();
-        window.electronAPI.onPageData((data) => {
-            window.AICAData = deserializeAICAData(data);
-            console.log(window.AICAData.roomId);
-        });
+        window.AICAData = deserializeAICAData(JSON.parse(localStorage.getItem('AICAData') || '{}'));
         window.currentHtml = "renew_userdata";
         window.isRunning = false;
         // ページ読み込み時にユーザー情報をロード
@@ -158,7 +155,8 @@ renew_clientdata.htmlでのユーザーデータのアップデートとやり�
 
         // メイン画面に戻るボタンの処理（元のコードと同様）
         document.getElementById('back-btn').addEventListener('click', () => {
-            window.electronAPI.switchHtmlWithData('ui-smpl.html', serializeAICAData(window.AICAData));
+            localStorage.setItem('AICAData', JSON.stringify(serializeAICAData(window.AICAData)));
+            window.electronAPI.switchHtml('ui-smpl.html');
         });
 
 

--- a/ui-smpl.html
+++ b/ui-smpl.html
@@ -103,24 +103,6 @@ prompt読み込まなくなったので、不要なものが色々残ってる�
 
   <script src="common.js"></script>
   <script>
-    //@03d let onPageDataFired = false;
-    //@03d window.electronAPI.onPageData((data) => {
-    //@03d   onPageDataFired = true;
-    //@03d   window.AICAData = deserializeAICAData(data);
-    //@03d   // データを使用する処理
-    //@03d   console.log("AICAData.roomId:" + window.AICAData.roomId);
-    //@03d   checkRoomId();
-    //@03d });
-
-    //@03d document.addEventListener('DOMContentLoaded', () => {
-    //@03d   // onPageDataを待つために、setTimeoutで少し後に確認
-    //@03d   setTimeout(() => {
-    //@03d     if (!onPageDataFired) {
-    //@03d       // ここに到達した時点で onPageData が呼ばれていない→ミーティングIDを聞くダイアログ
-    //@03d       checkRoomId();
-    //@03d     }
-    //@03d   }, 300);
-    //@03d });
     // サーバーのURLとパスを指定して接続します
     //@02d const soc = io.connect('https://robo-aica.com');
     //@01d const roomId = prompt("Please enter your Meeting ID:");
@@ -257,7 +239,8 @@ prompt読み込まなくなったので、不要なものが色々残ってる�
 
     function switchTo(htmlFileName) {
       deleteEmptySession();
-      window.electronAPI.switchHtmlWithData(htmlFileName, dataToSwitch());
+      localStorage.setItem('AICAData', JSON.stringify(dataToSwitch()));
+      window.electronAPI.switchHtml(htmlFileName);
     }
 
     function dataToSwitch() {


### PR DESCRIPTION
## Summary
- save AICAData in localStorage before page changes and restore it on load
- drop obsolete switchHtmlWithData/onPageData IPC handlers
- update pages to use switchHtml and localStorage

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a110b031a08333a95724506abce3bc