### PR TITLE
Render session notes using Markdown

### DIFF
--- a/common.js
+++ b/common.js
@@ -38,7 +38,8 @@ function updateMarkdownPreview(textId, previewId) {
     const textarea = document.getElementById(textId);
     const preview = document.getElementById(previewId);
     if (!textarea || !preview) return;
-    preview.innerHTML = marked.parse(textarea.value);
+    const html = marked.parse(textarea.value);
+    preview.innerHTML = window.DOMPurify ? DOMPurify.sanitize(html) : html;
 }
 
 //#region 全体的なデータの準備

--- a/common.js
+++ b/common.js
@@ -32,6 +32,15 @@ function encodeFileName(str) {
         .replace(/[/\\?%*:|"<>]/g, '_');
 }
 
+// Markdown文字列をHTMLに変換して表示する
+function updateMarkdownPreview(textId, previewId) {
+    if (typeof marked === 'undefined') return;
+    const textarea = document.getElementById(textId);
+    const preview = document.getElementById(previewId);
+    if (!textarea || !preview) return;
+    preview.innerHTML = marked.parse(textarea.value);
+}
+
 //#region 全体的なデータの準備
 // 画面遷移時にデータを取得
 window.electronAPI.onPageData((data) => {
@@ -611,6 +620,8 @@ function displaySessionData() {
         document.getElementById("conversationData").value = "";
         document.getElementById("summaryData").value = "";
         document.getElementById("feedbackData").value = "";
+        updateMarkdownPreview('summaryData','summaryDataPreview');
+        updateMarkdownPreview('feedbackData','feedbackDataPreview');
         return;
     }
 
@@ -633,8 +644,10 @@ function displaySessionData() {
                 document.getElementById("conversationData").value = tmpConversationData ? tmpConversationData.textContent : "";
                 let tmpSummaryData = AICAData.sessionDataXML.getElementsByTagName("Summary")[0];
                 document.getElementById("summaryData").value = tmpSummaryData ? tmpSummaryData.textContent : "";
+                updateMarkdownPreview('summaryData','summaryDataPreview');
                 let tmpFeedbackData = AICAData.sessionDataXML.getElementsByTagName("CoachingFeedback")[0];
                 document.getElementById("feedbackData").value = tmpFeedbackData ? tmpFeedbackData.textContent : "";
+                updateMarkdownPreview('feedbackData','feedbackDataPreview');
             } else {
                 console.error('セッションデータの読み込みに失敗しました:', result.message);
                 alert('セッションデータの読み込みに失敗しました。');

--- a/finish.html
+++ b/finish.html
@@ -24,6 +24,7 @@ $password = $_POST['password'] ?? '';
     <link rel="stylesheet" type="text/css" href="styles-smpl.css">
 
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
 
     <style>
         html, body{

--- a/finish.html
+++ b/finish.html
@@ -23,6 +23,8 @@ $password = $_POST['password'] ?? '';
     <title>完了処理</title>
     <link rel="stylesheet" type="text/css" href="styles-smpl.css">
 
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+
     <style>
         html, body{
             height:100%;
@@ -76,12 +78,14 @@ $password = $_POST['password'] ?? '';
     <p>クライアント名: <span id="clientName"></span></p>
     <h2>セッションのまとめ</h2>
     <p>デモ用にあえて話していない情報も含めて表示しています</p>
-    <textarea id="clientRevisionTextArea"></textarea><br>
+    <textarea id="clientRevisionTextArea" oninput="updateMarkdownPreview('clientRevisionTextArea','clientRevisionTextAreaPreview')"></textarea>
+    <div id="clientRevisionTextAreaPreview" class="markdown-preview"></div><br>
     <button id="save-btn">上書き保存</button>
     <button id="send-email-btn">クライアントにメール送信する</button>
     <h2>セッションフィードバック</h2>
     <p>デモ用にあえて話していない情報も含めて表示しています</p>
-    <textarea id="coachingFeedback"></textarea><br>
+    <textarea id="coachingFeedback" oninput="updateMarkdownPreview('coachingFeedback','coachingFeedbackPreview')"></textarea>
+    <div id="coachingFeedbackPreview" class="markdown-preview"></div><br>
     <button id="back-btn">メイン画面に戻る</button>
     <script src="./transcript-processor.js"></script>
     <script src="common.js"></script>

--- a/renew_clientdata.html
+++ b/renew_clientdata.html
@@ -7,6 +7,8 @@
     <title>クライアントデータの表示・更新</title>
     <link rel="stylesheet" type="text/css" href="styles-smpl.css">
 
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+
     <style>
         /* [既存のスタイルはそのまま] */
         textarea {
@@ -187,11 +189,13 @@
             <!-- セッションのデータ表示 -->
             <div id="summary" class="tab-content active">
                 <!-- <h3>要約</h3> -->
-                <textarea id="summaryData"></textarea>
+                <textarea id="summaryData" oninput="updateMarkdownPreview('summaryData','summaryDataPreview')"></textarea>
+                <div id="summaryDataPreview" class="markdown-preview"></div>
             </div>
             <div id="feedback" class="tab-content">
                 <!-- <h3>コーチングフィードバック</h3> -->
-                <textarea id="feedbackData"></textarea>
+                <textarea id="feedbackData" oninput="updateMarkdownPreview('feedbackData','feedbackDataPreview')"></textarea>
+                <div id="feedbackDataPreview" class="markdown-preview"></div>
             </div>
             <div id="conversation" class="tab-content">
                 <!-- <h3>会話の文字起こし</h3> -->

--- a/renew_clientdata.html
+++ b/renew_clientdata.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" type="text/css" href="styles-smpl.css">
 
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
 
     <style>
         /* [既存のスタイルはそのまま] */

--- a/styles-smpl.css
+++ b/styles-smpl.css
@@ -73,6 +73,16 @@ select {
   font-size: medium;
 }
 
+.markdown-preview {
+  width: calc(100% - 26px);
+  border-width: 1px;
+  border-radius: 10px;
+  padding: 8px 8px 8px 8px;
+  margin: 5px 5px 5px 5px;
+  background-color: #fdf6e7;
+  font-size: medium;
+}
+
 .display-area {
   width: 100%;
   border-radius: 15px;

--- a/transcript-processor.js
+++ b/transcript-processor.js
@@ -449,6 +449,7 @@ function addDisplayData(displayAreaId, responseData) {
     }
     textarea.value += responseData.trim(); // 逐次データを追加
     textarea.scrollTop = textarea.scrollHeight; // スクロールを最下部に移動
+    updateMarkdownPreview(displayAreaId, displayAreaId + 'Preview');
 }
 
 // 返答の文字列を追加する。 セパレーターなし
@@ -456,6 +457,7 @@ function addDisplayDataNoSeperator(displayAreaId, responseData) {
     var textarea = document.getElementById(displayAreaId);
     textarea.value += responseData.trim(); // 逐次データを追加
     textarea.scrollTop = textarea.scrollHeight; // スクロールを最下部に移動
+    updateMarkdownPreview(displayAreaId, displayAreaId + 'Preview');
 }
 //#endregion
 
@@ -681,8 +683,10 @@ async function processGPTRequest(postData, resultElementID = null,iChat = null) 
             // Decode the chunk and append it to the result container
             const chunk = decoder.decode(value, { stream: !done });
             resultContainer.textContent += chunk;
+            updateMarkdownPreview(elementID, elementID + 'Preview');
         }
         saveCoachingFeedback(resultContainer.textContent);
+        updateMarkdownPreview(elementID, elementID + 'Preview');
     }else if (elementID == "clientRevisionTextArea") {
         resultContainer.textContent = '';  // Clear previous result
         while (!done) {
@@ -691,8 +695,10 @@ async function processGPTRequest(postData, resultElementID = null,iChat = null) 
             // Decode the chunk and append it to the result container
             const chunk = decoder.decode(value, { stream: !done });
             resultContainer.textContent += chunk;
+            updateMarkdownPreview(elementID, elementID + 'Preview');
         }
         saveSessionRevision(resultContainer.textContent);
+        updateMarkdownPreview(elementID, elementID + 'Preview');
     }
 }
 


### PR DESCRIPTION
## Summary
- display session summaries and coaching feedback using Markdown on finish and client data pages
- centralize Markdown rendering logic and live preview updates
- add style rules for Markdown preview blocks

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a18f99191c833397ad36dca2299117