### PR TITLE
feat: add manual transcription controls

### DIFF
--- a/main.js
+++ b/main.js
@@ -143,6 +143,20 @@ function createWindow() {
     mainWindow.setTitle(`AICA`);
 }
 
+// 音声認識アプリを終了する関数
+function stopSpeechRecognition() {
+    if (!speechRecognitionProcess) {
+        console.log('Speech recognition is not running');
+        return;
+    }
+
+    try {
+        speechRecognitionProcess.kill();
+    } catch (error) {
+        console.error('Failed to stop speech recognition:', error);
+    }
+}
+
 app.whenReady().then(() => {
 
     try {
@@ -164,10 +178,7 @@ app.whenReady().then(() => {
 
     createWindow();
 
-    //@04a. 少し遅延させて音声認識を起動
-    setTimeout(() => {
-        startSpeechRecognition();
-    }, 2000);
+
 
     app.on('activate', () => {
         if (BrowserWindow.getAllWindows().length === 0) {
@@ -184,9 +195,7 @@ app.on('window-all-closed', () => {
 
 //@04a.start アプリ終了時に音声認識プロセスも終了
 app.on('before-quit', () => {
-    if (speechRecognitionProcess) {
-        speechRecognitionProcess.kill();
-    }
+    stopSpeechRecognition();
 });
 
 // IPCハンドラー（音声認識の状態を取得）
@@ -195,6 +204,16 @@ ipcMain.handle('get-speech-service', () => {
         service: getSpeechService(),
         isRunning: speechRecognitionProcess !== null
     };
+});
+
+ipcMain.handle('start-speech-recognition', () => {
+    startSpeechRecognition();
+    return { status: speechRecognitionProcess ? 'started' : 'error' };
+});
+
+ipcMain.handle('stop-speech-recognition', () => {
+    stopSpeechRecognition();
+    return { status: 'stopped' };
 });
 //@04a.finish
 

--- a/preload.js
+++ b/preload.js
@@ -20,5 +20,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getSpeechService: () => ipcRenderer.invoke('get-speech-service'),                   //@04a
     onSpeechRecognitionStatus: (callback) => {                                          //@04a
         ipcRenderer.on('speech-recognition-status', (event, data) => callback(data));   //@04a
-    }                                                                                   //@04a
+    },                                                                                  //@04a
+    startSpeechRecognition: () => ipcRenderer.invoke('start-speech-recognition'),
+    stopSpeechRecognition: () => ipcRenderer.invoke('stop-speech-recognition')
 });

--- a/styles-smpl.css
+++ b/styles-smpl.css
@@ -4,8 +4,26 @@ body {
 
 div#top{
   height: 2em;
-  display: none;
-  align-items: flex-end;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#transcriptionStatus {
+  font-size: 0.9em;
+}
+
+.running {
+  color: #008000;
+}
+
+.stopped {
+  color: #555555;
+}
+
+.warning {
+  color: #ff0000;
+  font-weight: bold;
 }
 div#top textarea{
   height: 1em;

--- a/ui-smpl.html
+++ b/ui-smpl.html
@@ -21,8 +21,9 @@ prompt読み込まなくなったので、不要なものが色々残ってる�
 
 <body>
   <div id="top">
-    <button id="start" style="display: none;">Start recording</button>
-    <button id="stop" style="display: none;">Stop recording</button>
+    <button id="start" disabled>文字起こし開始</button>
+    <button id="stop" disabled>文字起こし終了</button>
+    <span id="transcriptionStatus" class="stopped">停止中</span>
     <button id="summary" style="display: none;">Summary</button>
   </div>
   <div class="container">
@@ -129,7 +130,80 @@ prompt読み込まなくなったので、不要なものが色々残ってる�
     // メッセージIDとメッセージ内容のマッピングを保持するオブジェクト
     const messages = {}; //テスト用に一時的にコメントアウトにしている
 
-    // 
+    const startButton = document.getElementById('start');
+    const stopButton = document.getElementById('stop');
+    const statusText = document.getElementById('transcriptionStatus');
+    let speechServiceRunning = false;
+    let startCheckTimer = null;
+    window.isRunning = false;
+
+    function updateStatus(mode) {
+      statusText.classList.remove('running', 'stopped', 'warning');
+      if (mode === 'running') {
+        statusText.textContent = '文字起こし中';
+        statusText.classList.add('running');
+      } else if (mode === 'warning') {
+        statusText.textContent = '警告: 文字起こしが動作していません';
+        statusText.classList.add('warning');
+      } else if (mode === 'starting') {
+        statusText.textContent = '起動中...';
+        statusText.classList.add('stopped');
+      } else {
+        statusText.textContent = '停止中';
+        statusText.classList.add('stopped');
+      }
+    }
+
+    updateStatus('stopped');
+    startButton.disabled = true;
+    stopButton.disabled = true;
+
+    startButton.addEventListener('click', startTranscription);
+    stopButton.addEventListener('click', stopTranscription);
+
+    function startTranscription() {
+      if (window.isRunning) return;
+      addNewSession();
+      constantSaveTranscription();
+      window.isRunning = true;
+      startButton.disabled = true;
+      stopButton.disabled = false;
+      updateStatus('starting');
+      speechServiceRunning = false;
+      window.electronAPI.startSpeechRecognition();
+      startCheckTimer = setTimeout(() => {
+        if (!speechServiceRunning) {
+          updateStatus('warning');
+        }
+      }, 3000);
+    }
+
+    function stopTranscription() {
+      if (!window.isRunning) return;
+      window.isRunning = false;
+      window.electronAPI.stopSpeechRecognition();
+      startButton.disabled = false;
+      stopButton.disabled = true;
+      updateStatus('stopped');
+    }
+
+    window.electronAPI.onSpeechRecognitionStatus(data => {
+      if (data.status === 'started') {
+        speechServiceRunning = true;
+        updateStatus('running');
+        if (startCheckTimer) clearTimeout(startCheckTimer);
+      } else if (data.status === 'stopped') {
+        speechServiceRunning = false;
+        if (window.isRunning) {
+          updateStatus('warning');
+        } else {
+          updateStatus('stopped');
+        }
+        if (startCheckTimer) clearTimeout(startCheckTimer);
+      }
+    });
+
+    //
     // WebSocketサーバーの URL（C# 側で起動している wsServer のエンドポイント）
     const ws = new WebSocket("ws://localhost:8181/ws/");
 
@@ -206,11 +280,15 @@ prompt読み込まなくなったので、不要なものが色々残ってる�
     // freeImputArea
     async function startNewSession() {
       console.log("startNewSession");
+      if (window.isRunning) {
+        stopTranscription();
+      }
       await deleteEmptySession();
-      window.isRunning = true;
+      window.isRunning = false;
       setSelectedClient();
-      addNewSession();
-      constantSaveTranscription();
+      startButton.disabled = false;
+      stopButton.disabled = true;
+      updateStatus('stopped');
     }
 
 
@@ -265,11 +343,6 @@ prompt読み込まなくなったので、不要なものが色々残ってる�
       window.AICAData.mainTranscription = getTranscription("main");
       return serializeAICAData(window.AICAData);
     }
-
-    //@04a.preload経由で起動／停止イベントをログに出力する
-    window.electronAPI.onSpeechRecognitionStatus(data => {
-      console.log(`[SpeechService] status=${data.status}, service=${data.service}`);
-    });
 
   </script>
   <script src="./transcript-processor.js"></script>


### PR DESCRIPTION
## Summary
- add IPC handlers to start and stop speech recognition
- expose start/stop to renderer and wire UI buttons with status indicator
- style top bar to show transcription state and warnings

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1111658948333ade1e77adf7520d6