### PR TITLE
Render session summaries and feedback with Markdown preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/common.js
+++ b/common.js
@@ -616,6 +616,8 @@ function displaySessionData() {
         document.getElementById("conversationData").value = "";
         document.getElementById("summaryData").value = "";
         document.getElementById("feedbackData").value = "";
+        if (typeof updateSummaryPreview === 'function') updateSummaryPreview();
+        if (typeof updateFeedbackPreview === 'function') updateFeedbackPreview();
         return;
     }
 
@@ -640,6 +642,8 @@ function displaySessionData() {
                 document.getElementById("summaryData").value = tmpSummaryData ? tmpSummaryData.textContent : "";
                 let tmpFeedbackData = AICAData.sessionDataXML.getElementsByTagName("CoachingFeedback")[0];
                 document.getElementById("feedbackData").value = tmpFeedbackData ? tmpFeedbackData.textContent : "";
+                if (typeof updateSummaryPreview === 'function') updateSummaryPreview();
+                if (typeof updateFeedbackPreview === 'function') updateFeedbackPreview();
             } else {
                 console.error('セッションデータの読み込みに失敗しました:', result.message);
                 alert('セッションデータの読み込みに失敗しました。');

--- a/finish.html
+++ b/finish.html
@@ -38,6 +38,16 @@ $password = $_POST['password'] ?? '';
             background-color: #fdf6e7;
             font-size: medium;
         }
+        .markdown-preview {
+            width: calc(100% - 26px);
+            min-height: 50px;
+            border-width: 1px;
+            border-radius: 10px;
+            padding: 8px 8px 8px 8px;
+            margin: 5px 5px 5px 5px;
+            background-color: #ffffff;
+            font-size: medium;
+        }
         /* ボタン */
         button {
             min-width: 18%;
@@ -76,13 +86,18 @@ $password = $_POST['password'] ?? '';
     <p>クライアント名: <span id="clientName"></span></p>
     <h2>セッションのまとめ</h2>
     <p>デモ用にあえて話していない情報も含めて表示しています</p>
-    <textarea id="clientRevisionTextArea"></textarea><br>
+    <textarea id="clientRevisionTextArea"></textarea>
+    <div id="clientRevisionPreview" class="markdown-preview"></div>
+    <br>
     <button id="save-btn">上書き保存</button>
     <button id="send-email-btn">クライアントにメール送信する</button>
     <h2>セッションフィードバック</h2>
     <p>デモ用にあえて話していない情報も含めて表示しています</p>
-    <textarea id="coachingFeedback"></textarea><br>
+    <textarea id="coachingFeedback"></textarea>
+    <div id="coachingFeedbackPreview" class="markdown-preview"></div>
+    <br>
     <button id="back-btn">メイン画面に戻る</button>
+    <script src="markdown.js"></script>
     <script src="./transcript-processor.js"></script>
     <script src="common.js"></script>
 
@@ -112,6 +127,8 @@ $password = $_POST['password'] ?? '';
             displayLastSelectedUserData();
             getUserRevision();
             getFeedback();
+            updateClientRevisionPreview();
+            updateCoachingFeedbackPreview();
         }
 
 
@@ -163,6 +180,30 @@ $password = $_POST['password'] ?? '';
             localStorage.setItem('AICAData', JSON.stringify(serializeAICAData(window.AICAData)));
             window.electronAPI.switchHtml('ui-smpl.html');
         });
+
+        function renderMarkdown(sourceId, previewId) {
+            const text = document.getElementById(sourceId).value;
+            document.getElementById(previewId).innerHTML = parseMarkdown(text);
+        }
+
+        function updateClientRevisionPreview() {
+            renderMarkdown('clientRevisionTextArea', 'clientRevisionPreview');
+        }
+
+        function updateCoachingFeedbackPreview() {
+            renderMarkdown('coachingFeedback', 'coachingFeedbackPreview');
+        }
+
+        function updateMarkdownPreview(targetId) {
+            if (targetId === 'clientRevisionTextArea') {
+                updateClientRevisionPreview();
+            } else if (targetId === 'coachingFeedback') {
+                updateCoachingFeedbackPreview();
+            }
+        }
+
+        document.getElementById('clientRevisionTextArea').addEventListener('input', updateClientRevisionPreview);
+        document.getElementById('coachingFeedback').addEventListener('input', updateCoachingFeedbackPreview);
 
     </script>
 </body>

--- a/markdown.js
+++ b/markdown.js
@@ -1,0 +1,20 @@
+function parseMarkdown(text) {
+    if (!text) return "";
+    let html = text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+    // unordered lists
+    html = html.replace(/(^|\n)([-*] .+(?:\n[-*] .+)*)/g, function(_, p1, block) {
+        const items = block.split(/\n/).map(line => '<li>' + line.substring(2).trim() + '</li>').join('');
+        return p1 + '<ul>' + items + '</ul>';
+    });
+    html = html.replace(/^### (.*)$/gm, '<h3>$1</h3>')
+               .replace(/^## (.*)$/gm, '<h2>$1</h2>')
+               .replace(/^# (.*)$/gm, '<h1>$1</h1>');
+    html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+               .replace(/\*(.+?)\*/g, '<em>$1</em>');
+    html = html.replace(/\n/g, '<br>');
+    return html;
+}
+window.parseMarkdown = parseMarkdown;

--- a/renew_clientdata.html
+++ b/renew_clientdata.html
@@ -132,6 +132,16 @@
         #back-btn:hover {
             background-color: #bc8f8f; /* Slightly darker shade on hover */
         }
+        .markdown-preview {
+            width: calc(100% - 26px);
+            border-width: 1px;
+            border-radius: 10px;
+            min-height: 30px;
+            padding: 8px 8px 8px 8px;
+            margin: 5px 5px 5px 5px;
+            background-color: #ffffff;
+            font-size: medium;
+        }
     </style>
 
 
@@ -188,10 +198,12 @@
             <div id="summary" class="tab-content active">
                 <!-- <h3>要約</h3> -->
                 <textarea id="summaryData"></textarea>
+                <div id="summaryDataPreview" class="markdown-preview"></div>
             </div>
             <div id="feedback" class="tab-content">
                 <!-- <h3>コーチングフィードバック</h3> -->
                 <textarea id="feedbackData"></textarea>
+                <div id="feedbackDataPreview" class="markdown-preview"></div>
             </div>
             <div id="conversation" class="tab-content">
                 <!-- <h3>会話の文字起こし</h3> -->
@@ -214,6 +226,7 @@
     </div>
     <div id="footer" class="bottom-buttons"></div>
     <button id="back-btn">メイン画面に戻る</button></div>
+    <script src="markdown.js"></script>
     <script src="common.js"></script>
     <script>
         window.AICAData = deserializeAICAData(JSON.parse(localStorage.getItem('AICAData') || '{}'));
@@ -257,6 +270,22 @@
             localStorage.setItem('AICAData', JSON.stringify(serializeAICAData(window.AICAData)));
             window.electronAPI.switchHtml('ui-smpl.html');
         });
+
+        function renderMarkdown(sourceId, previewId) {
+            const text = document.getElementById(sourceId).value;
+            document.getElementById(previewId).innerHTML = parseMarkdown(text);
+        }
+
+        function updateSummaryPreview() {
+            renderMarkdown('summaryData', 'summaryDataPreview');
+        }
+
+        function updateFeedbackPreview() {
+            renderMarkdown('feedbackData', 'feedbackDataPreview');
+        }
+
+        document.getElementById('summaryData').addEventListener('input', updateSummaryPreview);
+        document.getElementById('feedbackData').addEventListener('input', updateFeedbackPreview);
     </script>
 
 </body>

--- a/transcript-processor.js
+++ b/transcript-processor.js
@@ -449,6 +449,9 @@ function addDisplayData(displayAreaId, responseData) {
     }
     textarea.value += responseData.trim(); // 逐次データを追加
     textarea.scrollTop = textarea.scrollHeight; // スクロールを最下部に移動
+    if (typeof updateMarkdownPreview === 'function') {
+        updateMarkdownPreview(displayAreaId);
+    }
 }
 
 // 返答の文字列を追加する。 セパレーターなし
@@ -456,6 +459,9 @@ function addDisplayDataNoSeperator(displayAreaId, responseData) {
     var textarea = document.getElementById(displayAreaId);
     textarea.value += responseData.trim(); // 逐次データを追加
     textarea.scrollTop = textarea.scrollHeight; // スクロールを最下部に移動
+    if (typeof updateMarkdownPreview === 'function') {
+        updateMarkdownPreview(displayAreaId);
+    }
 }
 //#endregion
 


### PR DESCRIPTION
## Summary
- add simple markdown parser and preview elements for session summary and feedback
- show rendered markdown on session finish and client data pages
- update utilities to refresh markdown previews as data changes

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a20b19bd388333881dab08dcee4ba3